### PR TITLE
final walkthrough

### DIFF
--- a/instruqt-tracks/terraform-build-your-own-provider/implement-a-complex-read/check-workstation
+++ b/instruqt-tracks/terraform-build-your-own-provider/implement-a-complex-read/check-workstation
@@ -31,9 +31,9 @@ if ! grep -q 'func flattenOrderItemsData' "$DATA_SOURCE_ORDERS_FILE"; then
     exit 1
 fi
 
-# Check `hashicups/provider.go` has `hashicup_order` as a data source
+# Check `hashicups/provider.go` has `hashicups_order` as a data source
 if ! grep -q 'hashicups_order' "$PROVIDER_FILE"; then
-    fail-message "You need to add 'hashicup_order' data source in '$PROVIDER_FILE'."
+    fail-message "You need to add 'hashicups_order' data source in '$PROVIDER_FILE'."
     exit 1
 fi
 

--- a/instruqt-tracks/terraform-build-your-own-provider/implement-import/check-workstation
+++ b/instruqt-tracks/terraform-build-your-own-provider/implement-import/check-workstation
@@ -11,6 +11,28 @@ if [ ! -f $TF_IMPORT_MAIN_FILE ]; then
     exit 1
 fi
 
-# TODO: check the contents of the main.tf file
+# Check the `main.tf` file has the new sample resource
+if ! grep -q 'resource "hashicups_order" "sample"' "$TF_IMPORT_MAIN_FILE"; then
+    fail-message "You need to add the Terraform configuration for the 'hashicups_order' sample resource in the 'examples/import/main.tf' file."
+    exit 1
+fi
+
+# Check that an order was created
+if ! grep -q 'terraform import hashicups_order.sample' "$BASH_HISTORY_FILE"; then
+    fail-message "You haven't run `terraform import hashicups_order.sample <ID>` yet.  Be sure to reference the order ID based on the output following the order creation."
+    exit 1
+fi
+
+# Check that order was imported into terraform
+if ! grep -q 'localhost:19090/orders' "$BASH_HISTORY_FILE"; then
+    fail-message "You haven't created the order via HashiCups API yet.  Find the 'curl -X POST' command to create the order."
+    exit 1
+fi
+
+# Check if user used the 'terrafrom state' command
+if ! grep -q 'terraform state show hashicups_order.sample' "$BASH_HISTORY_FILE"; then
+    fail-message "You haven't created the order via HashiCups API yet.  Find the 'curl -X POST' command to create the order."
+    exit 1
+fi
 
 # TODO: check the state file and see that something has been imported - currently this stage does not work

--- a/instruqt-tracks/terraform-build-your-own-provider/setup-and-implement-read/check-workstation
+++ b/instruqt-tracks/terraform-build-your-own-provider/setup-and-implement-read/check-workstation
@@ -20,7 +20,7 @@ fi
 
 # Check `hashicups/provider.go` has `hashicup_coffees` as a data source
 if ! grep -q 'hashicups_coffees' "$PROVIDER_FILE"; then
-    fail-message "You need to add 'hashicup_coffees' data source in '$PROVIDER_FILE'."
+    fail-message "You need to add 'hashicups_coffees' data source in '$PROVIDER_FILE'."
     exit 1
 fi
 

--- a/instruqt-tracks/terraform-build-your-own-provider/track.yml
+++ b/instruqt-tracks/terraform-build-your-own-provider/track.yml
@@ -1091,6 +1091,7 @@ challenges:
     Next, initialize your workspace to refresh your HashiCups provider, then apply.
 
     ```
+    rm .terraform.lock.hcl
     terraform init && terraform apply --auto-approve
     ```
 


### PR DESCRIPTION
In summary, I think it's practically there to have Roger review it.  My commit includes changing some minor typos.  I also added checks to the implement-import challenge.  

Some additional observations:

### Add Authentication to a Provider

Challenge completes successfully even before the terraform init and apply.  Maybe it's referencing state from the previous exercise?

### Implement a Complex Read

The 'terraform init && terraform apply --auto-approve' step failed to due the lock.  I noticed there is an rm command to remove the lock file in the setup script before the challenge, so I'm not sure why the lock file persists at the start of this lab.  rm .terraform.lock.hcl and re-running init and apply passed the challenge as expected.

### Debug a Terraform Provider

Added `rm.terraform.lock.hcl` before the `terraform init && terraform apply --auto-approve` step.  Otherwise, there is a "Error: Failed to install provider" message.